### PR TITLE
Item improvements and miniframe signals

### DIFF
--- a/collage/background/grid.gdshader
+++ b/collage/background/grid.gdshader
@@ -28,13 +28,13 @@ float grid(float width, vec2 uv) {
 	//COLOR = vec4((drawWidth + lineAA).x * 5.0, 0.0, 0.0, 1.0);
     grid2 *= clamp(width / drawWidth, 0.0, 1.0);
     grid2 = mix(grid2, vec2(width), clamp(uvDeriv * 2.0 - 1.0, 0.0, 1.0));
-	
+
 	return mix(grid2.x, 1.0, grid2.y);
 }
 
 void fragment() {
 	vec2 uv0 = world_position / grid0_size;
 	vec2 uv1 = world_position / grid1_size;
-	
+
 	COLOR = mix(COLOR, line_color, max(grid(line0_width, uv0), grid(line1_width, uv1)));
 }

--- a/collage/main.tscn
+++ b/collage/main.tscn
@@ -39,6 +39,7 @@ amount = 4
 block_transfer_in = true
 block_transfer_out = false
 filtered = false
+slot_capacity = -1
 
 [sub_resource type="Resource" id="Resource_srp4f"]
 script = ExtResource("13_5xum0")
@@ -47,14 +48,16 @@ amount = 16
 block_transfer_in = false
 block_transfer_out = false
 filtered = true
+slot_capacity = -1
 
 [sub_resource type="Resource" id="Resource_vyl0g"]
 script = ExtResource("13_5xum0")
 item_type = ExtResource("15_abjog")
-amount = 5
+amount = 0
 block_transfer_in = false
 block_transfer_out = true
 filtered = false
+slot_capacity = 1
 
 [node name="Collage" type="Node2D" node_paths=PackedStringArray("camera", "inventory_menu", "selection_slot")]
 script = ExtResource("1_tiu0a")

--- a/collage/main.tscn
+++ b/collage/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://bn87h0cnlci4m"]
+[gd_scene load_steps=22 format=3 uid="uid://bn87h0cnlci4m"]
 
 [ext_resource type="Shader" path="res://collage/background/grid.gdshader" id="1_35pje"]
 [ext_resource type="Script" path="res://collage/collage.gd" id="1_tiu0a"]
@@ -11,10 +11,9 @@
 [ext_resource type="PackedScene" uid="uid://dp5rt3m1qgpgk" path="res://minigames/locksport/main.tscn" id="9_ci15t"]
 [ext_resource type="Script" path="res://items/containers/control_container.gd" id="11_1xkc3"]
 [ext_resource type="PackedScene" path="res://items/ui/selection_slot.tscn" id="12_527j7"]
-[ext_resource type="Script" path="res://items/inventories/item_descriptor.gd" id="12_n0468"]
+[ext_resource type="Script" path="res://items/inventories/item_slot.gd" id="13_5xum0"]
 [ext_resource type="Script" path="res://items/inventories/array_inventory.gd" id="13_g4iug"]
-[ext_resource type="Resource" uid="uid://kpkd0k7agsm0" path="res://items/default_items/key/key.tres" id="13_plkd0"]
-[ext_resource type="Resource" uid="uid://tjeiel15um82" path="res://items/default_items/brutus_dragon/brutus_dragon.tres" id="14_l2a5o"]
+[ext_resource type="Resource" uid="uid://tjeiel15um82" path="res://items/default_items/brutus_dragon/brutus_dragon.tres" id="14_ghplj"]
 [ext_resource type="Resource" uid="uid://u4ig0heqobt6" path="res://items/default_items/judgmental_puppy/judgmental_puppy.tres" id="15_abjog"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_l484h"]
@@ -33,35 +32,20 @@ colors = PackedColorArray(0, 0.301961, 0.560784, 1, 0, 0.301961, 0.560784, 1)
 gradient = SubResource("Gradient_oc1u4")
 width = 1
 
-[sub_resource type="Resource" id="Resource_06vha"]
-script = ExtResource("12_n0468")
-index = 0
-type = ExtResource("13_plkd0")
-amount = 2
+[sub_resource type="Resource" id="Resource_wfylo"]
+script = ExtResource("13_5xum0")
+item_type = ExtResource("14_ghplj")
+amount = 0
 
-[sub_resource type="Resource" id="Resource_6cu46"]
-script = ExtResource("12_n0468")
-index = 1
-type = ExtResource("14_l2a5o")
-amount = 18
-
-[sub_resource type="Resource" id="Resource_ogyky"]
-script = ExtResource("12_n0468")
-index = 2
-type = ExtResource("15_abjog")
+[sub_resource type="Resource" id="Resource_srp4f"]
+script = ExtResource("13_5xum0")
+item_type = ExtResource("15_abjog")
 amount = 16
 
-[sub_resource type="Resource" id="Resource_6ptyv"]
-script = ExtResource("12_n0468")
-index = 3
-type = ExtResource("15_abjog")
-amount = 14
-
-[sub_resource type="Resource" id="Resource_eefgw"]
-script = ExtResource("12_n0468")
-index = 4
-type = ExtResource("14_l2a5o")
-amount = 177
+[sub_resource type="Resource" id="Resource_vyl0g"]
+script = ExtResource("13_5xum0")
+item_type = ExtResource("15_abjog")
+amount = 5
 
 [node name="Collage" type="Node2D" node_paths=PackedStringArray("camera", "inventory_menu", "selection_slot")]
 script = ExtResource("1_tiu0a")
@@ -110,7 +94,7 @@ offset_left = 31.0
 offset_top = 29.0
 offset_right = 331.0
 offset_bottom = 229.0
-columns = 5
+columns = 3
 
 [node name="SelectionSlot" parent="DetachedUI" instance=ExtResource("12_527j7")]
 top_level = true
@@ -135,5 +119,4 @@ inventory = NodePath("ArrayInventory")
 
 [node name="ArrayInventory" type="Node" parent="TestContainer/GridInventoryMenu"]
 script = ExtResource("13_g4iug")
-size = 6
-descriptors = Array[ExtResource("12_n0468")]([SubResource("Resource_06vha"), SubResource("Resource_6cu46"), SubResource("Resource_ogyky"), SubResource("Resource_6ptyv"), SubResource("Resource_eefgw")])
+slots = Array[ExtResource("13_5xum0")]([SubResource("Resource_wfylo"), SubResource("Resource_srp4f"), SubResource("Resource_vyl0g")])

--- a/collage/main.tscn
+++ b/collage/main.tscn
@@ -38,6 +38,7 @@ item_type = ExtResource("14_ghplj")
 amount = 4
 block_transfer_in = true
 block_transfer_out = false
+filtered = false
 
 [sub_resource type="Resource" id="Resource_srp4f"]
 script = ExtResource("13_5xum0")
@@ -45,6 +46,7 @@ item_type = ExtResource("15_abjog")
 amount = 16
 block_transfer_in = false
 block_transfer_out = false
+filtered = true
 
 [sub_resource type="Resource" id="Resource_vyl0g"]
 script = ExtResource("13_5xum0")
@@ -52,6 +54,7 @@ item_type = ExtResource("15_abjog")
 amount = 5
 block_transfer_in = false
 block_transfer_out = true
+filtered = false
 
 [node name="Collage" type="Node2D" node_paths=PackedStringArray("camera", "inventory_menu", "selection_slot")]
 script = ExtResource("1_tiu0a")

--- a/collage/main.tscn
+++ b/collage/main.tscn
@@ -35,17 +35,23 @@ width = 1
 [sub_resource type="Resource" id="Resource_wfylo"]
 script = ExtResource("13_5xum0")
 item_type = ExtResource("14_ghplj")
-amount = 0
+amount = 4
+block_transfer_in = true
+block_transfer_out = false
 
 [sub_resource type="Resource" id="Resource_srp4f"]
 script = ExtResource("13_5xum0")
 item_type = ExtResource("15_abjog")
 amount = 16
+block_transfer_in = false
+block_transfer_out = false
 
 [sub_resource type="Resource" id="Resource_vyl0g"]
 script = ExtResource("13_5xum0")
 item_type = ExtResource("15_abjog")
 amount = 5
+block_transfer_in = false
+block_transfer_out = true
 
 [node name="Collage" type="Node2D" node_paths=PackedStringArray("camera", "inventory_menu", "selection_slot")]
 script = ExtResource("1_tiu0a")

--- a/coordinator/coordinator.tscn
+++ b/coordinator/coordinator.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://3uyaj3f23uvt"]
+[gd_scene load_steps=5 format=3 uid="uid://3uyaj3f23uvt"]
 
 [ext_resource type="Script" path="res://coordinator/coordinator.gd" id="1_j8w8t"]
 [ext_resource type="Script" path="res://coordinator/coordinator_debug.gd" id="2_eoxqf"]
 [ext_resource type="Script" path="res://items/inventories/array_inventory.gd" id="3_ix7p6"]
+[ext_resource type="Script" path="res://items/inventories/item_slot.gd" id="4_onyfw"]
 
 [node name="Coordinator" type="Node" node_paths=PackedStringArray("inventory")]
 script = ExtResource("1_j8w8t")
@@ -14,5 +15,5 @@ menu_name = "Coordinator"
 
 [node name="Inventory" type="Node" parent="."]
 script = ExtResource("3_ix7p6")
-size = 20
 inventory_name = "Collage Inventory"
+slots = Array[ExtResource("4_onyfw")]([null, null, null, null, null, null])

--- a/items/inventories/array_inventory.gd
+++ b/items/inventories/array_inventory.gd
@@ -4,52 +4,32 @@ extends Node
 ## Use existing methods wherever possible. If not, the underlying array is
 ## available as [member slots]. 
 
-@export var size: int = 5:
+var size: int:
+	get():
+		return slots.size()
 	set(value):
-		if value <= 0:
-			push_error("Cannot set inventory size <= 0!")
-			return
-		if is_node_ready():
-			resize(value)
-			
-		size = value
+		push_error("Tried to set size directly! Use the resize method instead.")
 
-## Desciptors for all the items that should be placed in here at runtime.
-## Adding anything to this after runtime does nothing.
-@export var descriptors: Array[ItemDescriptor] = []
 ## Display name of the inventory.
 @export var inventory_name: String = ""
 
-var slots: Array[ItemSlot] = []
+@export var slots: Array[ItemSlot] = []
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	resize(size)
-	
-	# Filling in all the descriptors
-	for descriptor in descriptors:
-		if descriptor.index >= size:
-			push_warning("Item descriptor index is out of bounds!")
-		else:
-			var slot: ItemSlot = slots[descriptor.index]
-			if is_instance_valid(slot.item_type):
-				push_warning("Item descriptor is overwriting items in slot!")
-			slot.item_type = descriptor.type
-			slot.amount = descriptor.amount
+	_fill_blanks()
 
-
-## Resizes the inventory.
+## Resizes the inventory. Also fills in nulls in the slots array with
+## blank ItemSlots
 func resize(new_size: int) -> void:
 	if new_size <= 0:
 		push_error("Cannot set inventory size <= 0!")
 		return
 			
 	slots.resize(new_size)
-	for i in slots.size():
-		if not is_instance_valid(slots[i]):
-			slots[i] = ItemSlot.new()
-			
+	_fill_blanks()
 	# If the inventory is shrinking resize will remove the old slots. No further action needed.
+
 
 ## Gets the total amount of items of type [param item_type] in the inventory.
 func amount_of(item_type: ItemType) -> int:
@@ -126,4 +106,10 @@ func slot_at(index: int) -> ItemSlot:
 func clear() -> void:
 	for slot in slots:
 		slot.clear()
-	
+
+## Fills in nulls in the slots array with blank ItemSlots.
+## Should never be needed outside of the class.
+func _fill_blanks() -> void:
+	for i in slots.size():
+		if not is_instance_valid(slots[i]):
+			slots[i] = ItemSlot.new()

--- a/items/inventories/item_descriptor.gd
+++ b/items/inventories/item_descriptor.gd
@@ -1,9 +1,0 @@
-class_name ItemDescriptor
-extends Resource
-## This class is to allow the user to add items to an inventory without
-## trying to access a large data structure in the inspector.
-## Designed for the [class ArrayInventory].
-
-@export_range(0, 100, 1, "or_greater") var index: int = 0
-@export var type: ItemType
-@export_range(0, 100, 1, "or_greater") var amount: int = 0 

--- a/items/inventories/item_slot.gd
+++ b/items/inventories/item_slot.gd
@@ -5,18 +5,17 @@ extends Resource
 ## Everything that needs to store objects should use this class, including temporary stores of items.
 ## Most ItemSlots should be stable and should live as long as their parent objects.
 ## That means do not clear out ItemSlots by creating new ones, use clear method instead.
-## Changing a ItemSlot's items should be done with methods. 
-## Try to avoid setting amount and item_type directly. Use the given methods instead.
-## DO NOT USE _amount and _item_type directly unless you know what you're doing.
+## [br]Changing a ItemSlot's items should be done with methods. 
+## Try to avoid setting [member amount] and [member item_type] directly. Use the given methods instead.
+## DO NOT USE [member _amount] and [member _item_type] directly unless you know what you're doing.
 ##
-## Further details:
-## Generally, this class tries to be as fool-proof as possible (if user sticks to
+## [br]Generally, this class tries to be as fool-proof as possible (if user sticks to
 ## established methods and properties.) Methods have lots of checks, sometimes redundant. 
-## General guarantees are as follows:
-## - Amount is always >= 0
-## - If either _item_type is null or _amount == 0, the ItemSlot is considered empty.
-## - Amount should never exceed the max_stack in item_type.
-## - Changes to slot should emit a changed signal.
+## [br]General guarantees are as follows:
+## [br]- [member amount] is always >= 0
+## [br]- If either [member _item_type] is null or [member _amount] == 0, the ItemSlot is considered empty.
+## [br]- [member amount] should never exceed the value from [method get_capacity].
+## [br]- Changes to slot should emit a changed signal.
 
 # Order matters here. It's important that Godot sets item_type first
 # and not amount. Otherwise the internal checks will clamp amount to 0.
@@ -30,7 +29,7 @@ extends Resource
 		_item_type = value
 		# Max stack of new item_type might be lower than the old one.
 		if (_amount > 0 and is_instance_valid(_item_type)):
-			_amount = clampi(_amount, 0, _item_type.max_stack)
+			_amount = clampi(_amount, 0, get_capacity())
 		
 		emit_changed()
 
@@ -41,7 +40,7 @@ extends Resource
 		return _amount if is_instance_valid(_item_type) else 0
 	set(value):
 		if is_instance_valid(_item_type):
-			_amount = clampi(value, 0, _item_type.max_stack)
+			_amount = clampi(value, 0, get_capacity())
 		else:
 			if value > 0:
 				push_warning("Attempted to set item amount while item_type is invalid!")
@@ -67,6 +66,11 @@ extends Resource
 	set(value):
 		filtered = value
 		emit_changed()
+## An additional limit on item quantity on top of [member item_type].max_stack.
+## The maximum amount the slot can have is the minimum of capacity and ItemType.max_stack.
+## Set to a negative value to defer to the ItemType.max_stack.
+@export var slot_capacity: int = -1
+
 
 ## Internal backing field for item_type. Do not manipulate directly unless you
 ## know what you're doing!
@@ -78,10 +82,20 @@ var _amount: int = 0
 func _init(new_item_type: ItemType = null, new_amount: int = 0) -> void:
 	if is_instance_valid(new_item_type):
 		_item_type = new_item_type
-		_amount = clampi(new_amount, 0, _item_type.max_stack)
+		_amount = clampi(new_amount, 0, get_capacity())
 	else:
 		_amount = 0
 		_item_type = null
+
+## Gets the maximum number of items this slot can hold.
+## Limited by [member slot_capacity] and ItemType.max_stack.
+func get_capacity() -> int:
+	if not is_instance_valid(_item_type):
+		return slot_capacity
+	elif slot_capacity < 0:
+		return _item_type.max_stack
+	else:
+		return mini(_item_type.max_stack, slot_capacity)
 
 ## Returns true if the slot is empty, false otherwise.
 func is_empty() -> bool:
@@ -90,7 +104,7 @@ func is_empty() -> bool:
 ## Returns true if the slot is full, false otherwise.
 ## Returns false if the slot has no items.
 func is_full() -> bool:
-	return is_instance_valid(_item_type) and amount >= _item_type.max_stack 
+	return is_instance_valid(_item_type) and amount >= get_capacity()
 	
 ## Gets the texture of the item_type.
 ## If slot is empty, then this method will return null.
@@ -112,7 +126,7 @@ func add(addend: int) -> int:
 		return 0
 		
 	var amount_before: int = _amount
-	_amount = clampi(_amount + addend, 0, _item_type.max_stack)
+	_amount = clampi(_amount + addend, 0, get_capacity())
 	emit_changed()
 	return _amount - amount_before
 	
@@ -135,7 +149,7 @@ func add_item(type: ItemType, addend: int) -> int:
 		# Can't just use [method add] because that method has an empty check.
 		# This method can add items to an empty ItemSlot
 		var amount_before: int = _amount
-		_amount = clampi(_amount + addend, 0, _item_type.max_stack)
+		_amount = clampi(_amount + addend, 0, get_capacity())
 		emit_changed()
 		return _amount - amount_before
 	else:
@@ -173,11 +187,10 @@ func transfer_from(other: ItemSlot, max_amount: int) -> int:
 	if (stackable_with(other)):
 		# other is not empty (checked by guard clause) 
 		# And self._item_type == other._item_type, so self._item_type shouldn't be empty.
-		transferred = _item_type.max_stack - _amount # Self capacity limit
+		transferred = get_capacity() - _amount # Self capacity limit
 		# This is a min_int, not the synonym for small
 		transferred = mini(transferred, other._amount) # Don't take more than the other stack has
-		if max_amount != null:
-			transferred = mini(transferred, max_amount)
+		transferred = mini(transferred, max_amount)
 			
 		_amount += transferred
 		other.amount -= transferred # Using property here to trigger checks on other.
@@ -193,13 +206,13 @@ func replace(new_type: ItemType, new_amount: int) -> void:
 		return
 		
 	_item_type = new_type
-	_amount = clampi(new_amount, 0, _item_type.max_stack)
+	_amount = clampi(new_amount, 0, get_capacity())
 	
 ## Moves as many items as possible from [param other] onto self. 
 ## Returns the amount transferred. 
 func transfer_all_from(other: ItemSlot) -> int:
 	if is_instance_valid(other._item_type):
-		return transfer_from(other, other._item_type.max_stack)
+		return transfer_from(other, other.amount)
 	
 	return 0
 	

--- a/items/inventories/item_slot.gd
+++ b/items/inventories/item_slot.gd
@@ -49,6 +49,13 @@ extends Resource
 			
 		emit_changed()
 
+## If true, slot block transfers into the slot.
+## Only blocks transfer_from. Does not block other methods.
+@export var block_transfer_in: bool = false
+## If true, slot will allow items to be inserted
+## Only blocks transfer_from. Does not block other methods.
+@export var block_transfer_out: bool = false
+
 ## Internal backing field for item_type. Do not manipulate directly unless you
 ## know what you're doing!
 var _item_type: ItemType = null
@@ -125,6 +132,10 @@ func transfer_from(other: ItemSlot, max_amount: int) -> int:
 	
 	# Guard clauses. These won't change the object 
 	# so they don't need to emit_changed and can return directly.
+	if (block_transfer_in):
+		return 0
+	if (other.block_transfer_out):
+		return 0
 	if (other.is_empty()):
 		return 0
 	if (max_amount <= 0):
@@ -166,7 +177,7 @@ func replace(new_type: ItemType, new_amount: int) -> void:
 	
 ## Moves as many items as possible from [param other] onto self. 
 ## Returns the amount transferred. 
-func transfer_all(other: ItemSlot) -> int:
+func transfer_all_from(other: ItemSlot) -> int:
 	if is_instance_valid(other._item_type):
 		return transfer_from(other, other._item_type.max_stack)
 	

--- a/items/inventories/item_slot.gd
+++ b/items/inventories/item_slot.gd
@@ -51,13 +51,22 @@ extends Resource
 
 ## If true, slot block transfers into the slot.
 ## Only blocks transfer_from. Does not block other methods.
-@export var block_transfer_in: bool = false
+@export var block_transfer_in: bool = false:
+	set(value):
+		block_transfer_in = value
+		emit_changed()
 ## If true, slot will allow items to be inserted
 ## Only blocks transfer_from. Does not block other methods.
-@export var block_transfer_out: bool = false
+@export var block_transfer_out: bool = false:
+	set(value):
+		block_transfer_out = value
+		emit_changed()
 ## If true, the ItemSlot will not change item_type even when empty.
 ## Use this if there is a slot that should only be able to take one ItemType.
-@export var filtered: bool = false
+@export var filtered: bool = false:
+	set(value):
+		filtered = value
+		emit_changed()
 
 ## Internal backing field for item_type. Do not manipulate directly unless you
 ## know what you're doing!

--- a/items/item_transfer.gd
+++ b/items/item_transfer.gd
@@ -10,8 +10,11 @@ extends Object
 ## swap otherwise.
 static func standard_transfer(source: ItemSlot, destination: ItemSlot):
 	if not source.is_empty() and destination.stackable_with(source):
-		destination.transfer_all(source)
-	else:
+		destination.transfer_all_from(source)
+	elif source.is_empty():
+		source.transfer_all_from(destination)
+	elif not (source.block_transfer_in or source.block_transfer_out 
+			or destination.block_transfer_in or destination.block_transfer_out):
 		destination.swap(source)
 		
 ## Standard right-click behavior.
@@ -22,5 +25,6 @@ static func alternate_transfer(source: ItemSlot, destination: ItemSlot):
 	else:
 		if destination.stackable_with(source):
 			destination.transfer_from(source, 1)
-		else:
+		elif not (source.block_transfer_in or source.block_transfer_out 
+			or destination.block_transfer_in or destination.block_transfer_out):
 			destination.swap(source)

--- a/items/ui/item_slot_display.gd
+++ b/items/ui/item_slot_display.gd
@@ -36,17 +36,24 @@ func _gui_input(event: InputEvent) -> void:
 func update_display() -> void:
 	var texture: Texture2D = null
 	var amount_text: String = ""
+	var opacity = 1
 	tooltip_text = "" # tooltip_text is a field of Control.
 	
-	if is_instance_valid(slot) and not slot.is_empty():
+	if is_instance_valid(slot):
 		texture = slot.get_texture()
 		# If the max stack is only one, just show the icon and not the number.
-		amount_text = str(slot.amount) if slot.item_type.max_stack > 1 else ""
-		tooltip_text = slot.item_type.name + "\n" + slot.item_type.description
+		amount_text = str(slot.amount) if slot.amount > 1 else ""
+		if not slot.is_empty() or slot.filtered:
+			tooltip_text = slot.item_type.name + "\n" + slot.item_type.description
+		if slot.filtered and slot.is_empty():
+			# Filtered empty slots should be translucent to communicate
+			# that they are empty and to communicate the filter.
+			opacity = 0.5 
 		
 	# If the control nodes aren't set, assume that the user wants to not show them. 
 	if is_instance_valid(_item_texture):
 		_item_texture.texture = texture
+		_item_texture.self_modulate = Color(1, 1, 1, opacity)
 		
 	if is_instance_valid(_amount_label):
 		_amount_label.text = amount_text

--- a/items/ui/item_slot_display.gd
+++ b/items/ui/item_slot_display.gd
@@ -10,7 +10,7 @@ signal interacted(event: InputEvent)
 @export var _item_texture: TextureRect
 ## The [class Label] that will be used to display the amount in the slot.
 @export var _amount_label: Label
-# The slot that this display is displaying. If not set, it will be a new empty slot during runtime.
+## The slot that this display is displaying.
 @export var slot: ItemSlot = ItemSlot.new():
 	set(value):
 		if is_instance_valid(slot) and slot.changed.is_connected(update_display):

--- a/minigames/miniframe/miniframe.gd
+++ b/minigames/miniframe/miniframe.gd
@@ -31,10 +31,9 @@ signal scene_reloaded()
 ## Does not reload scene during runtime when changed.
 @export var scene: PackedScene:
 	set(value):
-		# @export variables call the setter before viewport is loaded
-		# Await ready to make sure that viewport isn't null.
 		scene = value
 		if Engine.is_editor_hint():
+			# Await ready to make sure that viewport isn't null.
 			if not is_node_ready():
 				await ready
 			reload_scene()

--- a/minigames/miniframe/miniframe.gd
+++ b/minigames/miniframe/miniframe.gd
@@ -33,10 +33,10 @@ signal scene_reloaded()
 	set(value):
 		# @export variables call the setter before viewport is loaded
 		# Await ready to make sure that viewport isn't null.
-		if not is_node_ready():
-			await ready
 		scene = value
 		if Engine.is_editor_hint():
+			if not is_node_ready():
+				await ready
 			reload_scene()
 		
 ## If true, pressing the reset key will automatically reload the scene.

--- a/minigames/miniframe/miniframe_template.tscn
+++ b/minigames/miniframe/miniframe_template.tscn
@@ -8,7 +8,6 @@ offset_right = 813.0
 offset_bottom = 464.0
 stretch = true
 script = ExtResource("1_q347j")
-frame_name = null
 viewport = NodePath("SubViewport")
 _frame_rect = NodePath("Frame")
 _frame_label = NodePath("Frame/FrameLabel")


### PR DESCRIPTION
Made some adjustments to the item system. ItemSlot had some restriction relaxed. The item descriptor system has also been removed for now. There shouldn't be enough ItemSlots to warrant that system. Using ItemSlots directly in the resource should be more intuitive.

Also added some more features for ItemSlot. It now has filters, transfer blocks, and slot capacity. Filtered slots will not change their item type and will block transfers if they don't match the type. Transfer blocks prevent transfers in/out. Useful for insert only or withdraw only slots. Slot capacity limits the capacity of a slot below its natural max stack. Useful for making key slots that won't eat an entire stack of keys.

Also snuck in some signals for miniframe. 